### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_ima_spec.rb
+++ b/spec/acceptance/suites/default/00_ima_spec.rb
@@ -24,6 +24,16 @@ describe 'ima class' do
     end
 
     hosts.each do |host|
+      # On a fresh node the Sicura console previews this module with
+      # `puppet apply --noop`, which must not error. Exercise that here before
+      # the real applies below. No package-removal step: ima manages kernel
+      # params/policy state only, so noop-only is the representative check.
+      context 'in noop mode from a clean state' do
+        it 'applies without errors in noop mode' do
+          apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+        end
+      end
+
       it 'runs puppet' do
         apply_manifest_on(host, manifest, catch_failures: true)
       end


### PR DESCRIPTION
On a fresh node the Sicura console previews this module with `puppet apply --noop`, which must not error. This adds a noop-from-clean-state example that applies the module manifest with `noop: true` before the existing applies. No package-removal step — ima manages config/state only, so noop-only is the representative check (matching the merged fips PR).