### PR TITLE
Fix catalog dependency failure from bare kernel_parameter references (#97)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Wed Jul 15 2026 Hazel Caballero <hazel@sicura.us> - 1.0.1
+- Fix catalog dependency resolution failure caused by referencing
+  `kernel_parameter` resources by bare title. The augeasproviders_grub
+  `kernel_parameter` type uses composite namevars, so `reboot_notify`
+  resources now receive `notify` from each `kernel_parameter` instead of
+  subscribing to them by title (matching the fips and selinux modules)
+
 * Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 1.0.0
 - Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
 - Point `issues_url` at GitHub Issues

--- a/manifests/appraise.pp
+++ b/manifests/appraise.pp
@@ -154,16 +154,18 @@ class ima::appraise(
   # If ima_appraise disabled
     kernel_parameter { ['ima_appraise', 'ima_appraise_tcb']:
       ensure   => absent,
-      bootmode => 'normal'
+      bootmode => 'normal',
+      notify   => Reboot_notify['ima_appraise_reboot']
     }
     file { "${scriptdir}/ima_security_attr_update.sh":
       ensure => absent
     }
   }
 
-  reboot_notify { 'ima_appraise_reboot':
-    subscribe => [
-      Kernel_parameter['ima_appraise_tcb'],
-    ]
-  }
+  # Notified from the kernel_parameter resources above rather than subscribing
+  # to them by title: the augeasproviders_grub kernel_parameter type uses
+  # composite namevars (name + bootmode), so a bare Kernel_parameter['...']
+  # reference does not resolve to a resource declared with bootmode => 'normal'
+  # and breaks catalog dependency resolution. See ima (init.pp) for detail.
+  reboot_notify { 'ima_appraise_reboot': }
 }

--- a/manifests/appraise/fixmode.pp
+++ b/manifests/appraise/fixmode.pp
@@ -26,9 +26,10 @@ class ima::appraise::fixmode(
     }
   }
 
-  reboot_notify { 'ima_appraise_fix_reboot':
-    subscribe => [
-      Kernel_parameter['ima_appraise'],
-    ]
-  }
+  # Notified from the kernel_parameter above rather than subscribing to it by
+  # title: the augeasproviders_grub kernel_parameter type uses composite
+  # namevars, so a bare Kernel_parameter['ima_appraise'] reference does not
+  # resolve to a resource declared with bootmode => 'normal'. See ima
+  # (init.pp).
+  reboot_notify { 'ima_appraise_fix_reboot': }
 }

--- a/manifests/appraise/relabel.pp
+++ b/manifests/appraise/relabel.pp
@@ -35,12 +35,14 @@ class ima::appraise::relabel(
         bootmode => 'normal',
         notify   => [ Reboot_notify['ima_appraise_enforce_reboot'], Exec['dracut ima appraise rebuild']]
       }
-      reboot_notify { 'ima_appraise_enforce_reboot':
-        subscribe => Kernel_parameter['ima_appraise']
-      }
+      # Both resources are notified from the kernel_parameter above rather
+      # than subscribing to it by title: the augeasproviders_grub
+      # kernel_parameter type uses composite namevars, so a bare
+      # Kernel_parameter['ima_appraise'] reference does not resolve to a
+      # resource declared with bootmode => 'normal'. See ima (init.pp).
+      reboot_notify { 'ima_appraise_enforce_reboot': }
       exec { 'dracut ima appraise rebuild':
         command     => '/sbin/dracut -f',
-        subscribe   => Kernel_parameter['ima_appraise'],
         refreshonly => true
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,8 @@ class ima (
 
     kernel_parameter { 'ima':
       value    => 'on',
-      bootmode => 'normal'
+      bootmode => 'normal',
+      notify   => Reboot_notify['ima_reboot']
     }
 
     $_ima_audit = $ima_audit ? {
@@ -76,23 +77,27 @@ class ima (
     }
     kernel_parameter { 'ima_audit':
       value    => $_ima_audit,
-      bootmode => 'normal'
+      bootmode => 'normal',
+      notify   => Reboot_notify['ima_reboot']
     }
 
-    if (versioncmp($facts[kernelmajversion],'3.13') >= 0) {
+    if (versioncmp($facts['kernelmajversion'],'3.13') >= 0) {
       kernel_parameter { 'ima_template':
         value    => $ima_template,
-        bootmode => 'normal'
+        bootmode => 'normal',
+        notify   => Reboot_notify['ima_reboot']
       }
       kernel_parameter { 'ima_hash':
         value    => $ima_hash,
-        bootmode => 'normal'
+        bootmode => 'normal',
+        notify   => Reboot_notify['ima_reboot']
       }
     }
     else {
       kernel_parameter { [ 'ima_template', 'ima_hash' ]:
         ensure   => 'absent',
-        bootmode => 'normal'
+        bootmode => 'normal',
+        notify   => Reboot_notify['ima_reboot']
       }
     }
 
@@ -114,17 +119,18 @@ class ima (
   else {
     kernel_parameter { [ 'ima', 'ima_audit', 'ima_template', 'ima_hash', 'ima_tcb' ]:
       ensure   => 'absent',
-      bootmode => 'normal'
+      bootmode => 'normal',
+      notify   => Reboot_notify['ima_reboot']
     }
   }
 
-  reboot_notify { 'ima_reboot':
-    subscribe => [
-      Kernel_parameter['ima'],
-      Kernel_parameter['ima_tcb'],
-      Kernel_parameter['ima_audit'],
-      Kernel_parameter['ima_template'],
-      Kernel_parameter['ima_hash']
-    ]
-  }
+  # Each kernel_parameter above declares `notify => Reboot_notify['ima_reboot']`
+  # rather than this resource subscribing to them by title. The
+  # kernel_parameter type (augeasproviders_grub) uses composite namevars
+  # (name + bootmode) and overrides its title to "<name>:<bootmode>", so a
+  # bare-title reference such as Kernel_parameter['ima'] no longer resolves to
+  # a resource declared with bootmode => 'normal' -- it fails catalog
+  # dependency resolution. Notifying from each resource avoids the title
+  # lookup entirely, matching the pattern in the fips and selinux modules.
+  reboot_notify { 'ima_reboot': }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ima",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "SIMP Team",
   "summary": "Manages IMA",
   "license": "Apache-2.0",

--- a/spec/classes/appraise/fixmode_spec.rb
+++ b/spec/classes/appraise/fixmode_spec.rb
@@ -26,7 +26,7 @@ describe 'ima::appraise' do
             ).that_notifies('Reboot_notify[ima_appraise_fix_reboot]')
         end
         it { is_expected.to contain_file('/tmp/simp/.ima_relabel').with({ 'ensure' => 'absent' }) }
-        it { is_expected.to contain_reboot_notify('ima_appraise_fix_reboot').that_subscribes_to('Kernel_parameter[ima_appraise]') }
+        it { is_expected.to contain_reboot_notify('ima_appraise_fix_reboot') }
       end
 
       context 'with relabel true' do
@@ -46,7 +46,7 @@ describe 'ima::appraise' do
           ).that_notifies('Reboot_notify[ima_appraise_fix_reboot]')
         end
         it { is_expected.to contain_file('/tmp/simp/.ima_relabel').with({ 'ensure' => 'file' }) }
-        it { is_expected.to contain_reboot_notify('ima_appraise_fix_reboot').that_subscribes_to('Kernel_parameter[ima_appraise]') }
+        it { is_expected.to contain_reboot_notify('ima_appraise_fix_reboot') }
       end
     end
   end

--- a/spec/classes/appraise/relabel_spec.rb
+++ b/spec/classes/appraise/relabel_spec.rb
@@ -27,15 +27,15 @@ describe 'ima::appraise' do
             .with(
               'value'    => 'enforce',
               'bootmode' => 'normal',
-            ).that_notifies('Exec[dracut ima appraise rebuild]')
+            ).that_notifies(['Reboot_notify[ima_appraise_enforce_reboot]', 'Exec[dracut ima appraise rebuild]'])
         }
         it {
           is_expected.to contain_exec('dracut ima appraise rebuild').with(
             'command'     => '/sbin/dracut -f',
             'refreshonly' => true,
-          ).that_subscribes_to('Kernel_parameter[ima_appraise]')
+          )
         }
-        it { is_expected.to contain_reboot_notify('ima_appraise_enforce_reboot').that_subscribes_to('Kernel_parameter[ima_appraise]') }
+        it { is_expected.to contain_reboot_notify('ima_appraise_enforce_reboot') }
       end
 
       context 'with ima_security_attr active' do

--- a/spec/classes/appraise_spec.rb
+++ b/spec/classes/appraise_spec.rb
@@ -8,6 +8,7 @@ shared_examples_for 'an ima appraise enabled system' do
   it { is_expected.to create_package('ima-evm-utils') }
   it { is_expected.to create_kernel_parameter('ima_appraise_tcb') }
   it { is_expected.to create_kernel_parameter('ima_appraise_tcb').with_bootmode('normal') }
+  it { is_expected.to create_kernel_parameter('ima_appraise_tcb').that_notifies('Reboot_notify[ima_appraise_reboot]') }
   it { is_expected.to create_kernel_parameter('rootflags').with_value('i_version') }
   it { is_expected.to create_kernel_parameter('rootflags').with_bootmode('normal') }
   it do
@@ -138,10 +139,12 @@ describe 'ima::appraise' do
         it do
           is_expected.to create_kernel_parameter('ima_appraise_tcb')
             .with('ensure' => 'absent')
+            .that_notifies('Reboot_notify[ima_appraise_reboot]')
         end
         it do
           is_expected.to create_kernel_parameter('ima_appraise')
             .with('ensure' => 'absent')
+            .that_notifies('Reboot_notify[ima_appraise_reboot]')
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,10 +16,12 @@ describe 'ima' do
         it { is_expected.not_to contain_reboot_notify('ima_log') }
         it { is_expected.to contain_kernel_parameter('ima').with_value('on') }
         it { is_expected.to contain_kernel_parameter('ima').with_bootmode('normal') }
+        it { is_expected.to contain_kernel_parameter('ima').that_notifies('Reboot_notify[ima_reboot]') }
         it { is_expected.to contain_kernel_parameter('ima_audit').with_value('0') }
         it { is_expected.to contain_kernel_parameter('ima_audit').with_bootmode('normal') }
         it { is_expected.to contain_kernel_parameter('ima_tcb') }
         it { is_expected.to contain_kernel_parameter('ima_tcb').with_bootmode('normal') }
+        it { is_expected.to contain_kernel_parameter('ima_tcb').that_notifies('Reboot_notify[ima_reboot]') }
 
         it do
           is_expected.to contain_mount('/sys/kernel/security').with(
@@ -78,6 +80,8 @@ describe 'ima' do
         it { is_expected.to contain_kernel_parameter('ima_hash').with_bootmode('normal') }
         it { is_expected.to contain_kernel_parameter('ima_tcb') }
         it { is_expected.to contain_kernel_parameter('ima_tcb').with_bootmode('normal') }
+        it { is_expected.to contain_kernel_parameter('ima').that_notifies('Reboot_notify[ima_reboot]') }
+        it { is_expected.to contain_kernel_parameter('ima_tcb').that_notifies('Reboot_notify[ima_reboot]') }
       end
 
       context 'with_kernel_version < 3.13' do
@@ -107,6 +111,8 @@ describe 'ima' do
         it { is_expected.to contain_kernel_parameter('ima_hash').with_bootmode('normal') }
         it { is_expected.to contain_kernel_parameter('ima_audit').with_value('1') }
         it { is_expected.to contain_kernel_parameter('ima_tcb') }
+        it { is_expected.to contain_kernel_parameter('ima').that_notifies('Reboot_notify[ima_reboot]') }
+        it { is_expected.to contain_kernel_parameter('ima_tcb').that_notifies('Reboot_notify[ima_reboot]') }
       end
 
       context 'with enable set to false' do
@@ -130,6 +136,8 @@ describe 'ima' do
         it { is_expected.to create_kernel_parameter('ima_template').with_bootmode('normal') }
         it { is_expected.to create_kernel_parameter('ima_hash').with_ensure('absent') }
         it { is_expected.to create_kernel_parameter('ima_hash').with_bootmode('normal') }
+        it { is_expected.to create_kernel_parameter('ima').that_notifies('Reboot_notify[ima_reboot]') }
+        it { is_expected.to create_kernel_parameter('ima_tcb').that_notifies('Reboot_notify[ima_reboot]') }
       end
     end
   end


### PR DESCRIPTION
Fixes #97.

`master` fails catalog compilation with `Could not retrieve dependency 'Kernel_parameter[ima]' of Reboot_notify[ima_reboot]`. The `augeasproviders_grub` `kernel_parameter` type uses composite namevars (`name` + `bootmode`) and overrides its title to `<name>:<bootmode>`, so a bare-title reference like `Kernel_parameter['ima']` no longer resolves to a resource declared with `bootmode => 'normal'`. This inverts the relationship in `init.pp`, `appraise.pp`, `appraise/relabel.pp`, and `appraise/fixmode.pp` so each `kernel_parameter` declares `notify => Reboot_notify['...']` instead of the `reboot_notify` subscribing by title — the same pattern the `fips` and `selinux` modules use. Also quotes the bareword `$facts[kernelmajversion]`.

Verified locally: full `spec/classes` suite passes (2128 examples, 0 failures) under Puppet 8.